### PR TITLE
Update README: project overview and products

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,31 @@
-# Reports
-This nests all **report cards** of active and past String products, mainly costing and north star metrics<br>
-Every report card should breakdown to cost per transaction + include team costs
+# String Reports
 
-## Live Sites
-- [Remarks Co-Pilot](https://reports.string.sg/remarkscopilot) (Q3 2023 to Present)
-- [String](https://reports.string.sg/string) (Q1 2023 to Present)
-- [Whine](https://reports.string.sg/whine) (Q1 2024 to Q2 2025)
+Public-facing product reports for the String volunteer-run edutech ecosystem. Tracks metrics, updates, and impact across all active and past products.
+
+Built with Next.js + Tailwind CSS v4. Deployed on Vercel.
+
+## Live Site
+
+[reports.string.sg](https://reports.string.sg)
+
+## Products
+
+| Product | Status | Report |
+|---|---|---|
+| String — Solutions Aggregator | Building | [/string-solutions](https://reports.string.sg/string-solutions) |
+| Events | Building | [/events](https://reports.string.sg/events) |
+| Diagrams | Building | [/diagrams](https://reports.string.sg/diagrams) |
+| Bingo | Maintenance | [/bingo](https://reports.string.sg/bingo) |
+| Whine — Problem Bank | Deprecated | [/whine](https://reports.string.sg/whine) |
+| Remarks Co-Pilot | Deprecated | [/remarkscopilot](https://reports.string.sg/remarkscopilot) |
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Contributing
+
+String runs entirely on volunteer effort. To contribute, visit [join.string.sg](https://join.string.sg).


### PR DESCRIPTION
Rewrite README to provide a clearer public-facing overview of the String reports project. Added project title, purpose, tech stack (Next.js + Tailwind CSS v4), canonical live site, a products table with statuses and report links, development instructions (npm install && npm run dev), and contributing information. Replaces the previous minimal "Reports" doc and live sites list with a more detailed products/statuses layout.