### PR TITLE
Fix/styling

### DIFF
--- a/app/[slug]/opengraph-image.tsx
+++ b/app/[slug]/opengraph-image.tsx
@@ -5,21 +5,6 @@ export const alt = "String Reports"
 export const size = { width: 1200, height: 630 }
 export const contentType = "image/png"
 
-export async function generateImageMetadata({
-  params,
-}: {
-  params: Promise<{ slug: string }>
-}) {
-  const { slug } = await params
-  const project = PROJECTS.find((p) => p.slug === slug)
-  return [
-    {
-      id: slug,
-      alt: project ? `${project.name} — String Reports` : "String Reports",
-    },
-  ]
-}
-
 const STATUS_COLOR: Record<string, string> = {
   Building:    "#75F8CC",
   Maintenance: "#C0F4FB",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,10 +18,6 @@ const spaceGrotesk = Space_Grotesk({
 export const metadata: Metadata = {
   title: 'String Reports',
   description: 'Impact metrics, updates and learnings from the String volunteer edutech ecosystem.',
-  openGraph: {
-    title: 'String Reports',
-    description: 'Impact metrics, updates and learnings from the String volunteer edutech ecosystem.',
-  },
   icons: {
     icon: [
       { url: '/icon-light-32x32.png', media: '(prefers-color-scheme: light)' },

--- a/string-brand.md
+++ b/string-brand.md
@@ -255,35 +255,37 @@ For Next.js App Router:
 
 ## OpenGraph
 
-Static OG image approach (matches diagrams.string.sg pattern).
+Dynamic OG images generated via Next.js `ImageResponse` (`next/og`). Each page gets its own branded image at build time — no static asset needed.
 
-### Asset spec
+### Files
 
-| File | Location | Dimensions |
-|------|----------|------------|
-| `og-image.jpg` | `public/` | 1280 × 1024 px |
+| File | Route | Description |
+|------|-------|-------------|
+| `app/opengraph-image.tsx` | `/` | Index page — shows aggregate stats (active products, teachers reached, volunteers) |
+| `app/[slug]/opengraph-image.tsx` | `/<slug>` | Detail pages — shows project name, tagline, highlight stat, status badge |
 
-### Metadata setup (`app/layout.tsx`)
+### Spec
 
-```ts
-export const metadata: Metadata = {
-  title: 'String Reports',
-  description: 'Impact metrics, updates and learnings from the String volunteer edutech ecosystem.',
-  openGraph: {
-    title: 'String Reports',
-    description: 'Impact metrics, updates and learnings from the String volunteer edutech ecosystem.',
-    images: [{ url: '/og-image.jpg', width: 1280, height: 1024 }],
-  },
-}
-```
+- **Size**: 1200 × 630 px (`export const size`)
+- **Format**: PNG (`export const contentType = "image/png"`)
+- **Alt**: set via `export const alt`
 
-### Guidelines
+### Design tokens used in OG images
 
-- OG image is set once at the root layout — all pages share the same image
-- Design the image on a dark background (`#1A1D1F`) using the String mint (`#75F8CC`) and Space Grotesk for any text, to stay on-brand
-- Recommended content: String logo / wordmark + tagline + URL (`reports.string.sg`)
-- Export as JPEG (not PNG) to keep file size small — aim for under 100 KB
-- Test with [opengraph.xyz](https://www.opengraph.xyz) or the Twitter Card Validator after deploying
+| Element | Value |
+|---------|-------|
+| Background | `#1A1D1F` |
+| Primary text | `#F0F0F0` |
+| Muted text | `#9CA3AF` |
+| Accent / wordmark | `#75F8CC` (String mint) |
+| Border / divider | `#3D4146` |
+| Font | `sans-serif` (system fallback — custom fonts require fetching via `fetch()` in the OG handler) |
+
+### Notes
+
+- Do **not** add `openGraph.images` to `layout.tsx` metadata — Next.js auto-discovers the `opengraph-image.tsx` files
+- Do **not** use `generateImageMetadata` unless a single route needs to return multiple images (not the case here)
+- Test rendered images with [opengraph.xyz](https://www.opengraph.xyz) after deploying
 
 ---
 


### PR DESCRIPTION
This pull request updates how OpenGraph (OG) images are handled in the project, moving from static image assets to dynamic generation using Next.js's `ImageResponse` API. It also updates documentation and metadata to align with this new approach, simplifying configuration and clarifying best practices.

**OpenGraph image handling improvements:**

* Replaced the static OG image approach with dynamic OG image generation via Next.js `ImageResponse`, allowing each page to have its own branded image generated at build time (`string-brand.md`).
* Removed the `generateImageMetadata` function from `app/[slug]/opengraph-image.tsx` since it's unnecessary for single-image routes; Next.js will now auto-discover OG image handlers. ([app/[slug]/opengraph-image.tsxL8-L22](diffhunk://#diff-89e221452dfa8cf07372d41622755986e6bf01ffbaba8de2af2c4afe755745e9L8-L22))

**Metadata and documentation updates:**

* Removed the `openGraph` field from the `metadata` export in `app/layout.tsx`, as OG image discovery is now handled automatically and does not require manual configuration.
* Updated `string-brand.md` documentation to reflect the new dynamic OG image setup, including file routes, image specs, and guidance on not using `openGraph.images` or `generateImageMetadata` unless multiple images per route are needed.