### PR TITLE
refactor: replace hardcoded brand hex with semantic tokens

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -31,7 +31,7 @@ export default async function ReportDetailPage({ params }: Props) {
   return (
     <div className="min-h-screen bg-background">
       {/* Nav */}
-      <header className="bg-[#33373B] border-b border-white/10">
+      <header className="bg-card border-b border-white/10">
         <div className="max-w-3xl mx-auto px-6 h-14 flex items-center justify-between">
           <Link href="/" className="text-sm font-semibold text-primary tracking-tight">
             Reports

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,7 +19,7 @@ export default function ReportsIndexPage() {
   return (
     <div className="min-h-screen bg-background">
       {/* Nav */}
-      <header className="bg-[#33373B] border-b border-white/10">
+      <header className="bg-card border-b border-white/10">
         <div className="max-w-5xl mx-auto px-6 h-14 flex items-center justify-between">
           <Link href="/" className="text-sm font-semibold text-primary tracking-tight">
             Reports

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -13,7 +13,7 @@ const STATUS_CONFIG: Record<
   Building: {
     label: "Building",
     className:
-      "bg-[#75F8CC]/15 text-[#75F8CC] border border-[#75F8CC]/30",
+      "bg-primary/15 text-primary border border-primary/30",
   },
   Prototype: {
     label: "Prototype",
@@ -23,7 +23,7 @@ const STATUS_CONFIG: Record<
   Maintenance: {
     label: "Maintenance",
     className:
-      "bg-[#C0F4FB]/15 text-[#C0F4FB] border border-[#C0F4FB]/30",
+      "bg-accent/15 text-accent border border-accent/30",
   },
   Deprecated: {
     label: "Deprecated",
@@ -132,7 +132,7 @@ export function ProjectCard({
           {audience.map((a) => (
             <span
               key={a}
-              className="text-xs text-[#75F8CC]/80 bg-[#75F8CC]/10 px-2 py-0.5 rounded-full"
+              className="text-xs text-primary/80 bg-primary/10 px-2 py-0.5 rounded-full"
             >
               {a}
             </span>


### PR DESCRIPTION
## Summary

Replaces inline `bg-[#75F8CC]`, `bg-[#C0F4FB]`, and `bg-[#33373B]` (and their text/border variants) with the equivalent `primary`, `accent`, and `card` semantic tokens already defined in `app/globals.css`. The tokens map 1:1 to the same hex values, so this is a pure refactor — no visual change.

This means future brand-color tweaks happen in one place (`globals.css`) instead of being scattered across components.

## Changes

- `components/project-card.tsx` — Building badge, Maintenance badge, audience pill
- `app/page.tsx` — header background
- `app/[slug]/page.tsx` — header background

## Out of scope

- `app/opengraph-image.tsx` and `app/[slug]/opengraph-image.tsx` keep their literal hex values. `next/og` renders to PNG at build/request time and cannot resolve CSS variables — they have to be hard-coded.

## Test plan

- [x] `npm run build` compiles cleanly
- [ ] Visually confirm Reports homepage header, Building badge (Diagrams, MatCHER, etc.), Maintenance badge (Remarks Co-Pilot), and audience pills render unchanged
- [ ] Visually confirm a detail page (e.g. `/remarkscopilot`) header is unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01R3r6gcKBceEVenfX5LhkxQ)_