### PR TITLE
fix(home): drop two-column mobile layout on aggregate stats

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,7 +49,7 @@ export default function ReportsIndexPage() {
         </div>
 
         {/* Aggregate stats strip */}
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-14 p-6 rounded-xl border border-border bg-card">
+        <div className="grid grid-cols-3 gap-4 mb-14 p-6 rounded-xl border border-border bg-card">
           <div>
             <p className="text-2xl font-bold text-foreground">{AGGREGATE.totalProjects}</p>
             <p className="text-xs text-muted-foreground mt-1">Active products</p>


### PR DESCRIPTION
## Summary

The aggregate stats strip used `grid-cols-2 md:grid-cols-3`, which on phones rendered "Active products" + "Teachers reached" on top and "Volunteer contributors" alone underneath — a visually orphan stat. The three numbers are short (`5`, `1.9k+`, `31+`) and fit three columns even at 360 px; labels wrap to a second line if needed but the strip stays balanced.

Changes `grid-cols-2 md:grid-cols-3` → `grid-cols-3` on the homepage stats container.

## Test plan

- [x] `npm run build` compiles
- [ ] Resize browser to 360 px, 768 px, 1024 px and confirm three balanced columns at every width
- [ ] Confirm "Volunteer contributors" label wraps acceptably at narrow widths (no clipped text)


---
_Generated by [Claude Code](https://claude.ai/code/session_01R3r6gcKBceEVenfX5LhkxQ)_