### PR TITLE
docs: add CLAUDE.md with architecture and conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,6 @@ App Router pages and OG handlers receive `params: Promise<{ slug: string }>` —
 - `next.config.mjs` sets `typescript.ignoreBuildErrors: true` and `images.unoptimized: true`. Type errors won't block production builds — run `npx tsc --noEmit` if you need to verify types. Images are unoptimised because the site is small and deployed statically.
 - `dev.md` is the running change log / decision record. When making non-trivial product or data decisions (status changes, aggregate methodology, new audience/problem types), append a dated entry there.
 
-## Branch
+## Contribution workflow
 
-Development happens on `claude/add-claude-documentation-ofJf0` (per session instructions). Push to that branch and open a draft PR.
+Work on the branch specified by the current task or follow the repository's standard branching workflow. When changes are ready, open a PR using the normal review process for the repository.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+`reports.string.sg` — public-facing impact reports for String, a volunteer-run edutech ecosystem. Static-rendered marketing site built with Next.js 16 (App Router) + React 19 + Tailwind v4 + shadcn/ui, deployed on Vercel.
+
+## Commands
+
+```bash
+npm install
+npm run dev      # next dev — local dev server
+npm run build    # next build — production build
+npm run start    # next start — serve built output
+npm run lint     # eslint .
+```
+
+No test suite exists.
+
+## Architecture
+
+### Content is data, not pages
+
+All product reports are entries in a single typed array: `lib/data.ts` → `PROJECTS: Project[]`. There is exactly **one dynamic route** (`app/[slug]/page.tsx`) that renders any project by slug, plus an index (`app/page.tsx`). `generateStaticParams` enumerates `PROJECTS` so every report is statically generated at build time. **Adding a new report = adding an entry to `PROJECTS`.** Do not create a per-product page file.
+
+### Aggregate stats are auto-computed
+
+`AGGREGATE` at the bottom of `lib/data.ts` derives `totalUsers` and `totalVolunteers` by summing the `teacherImpact` and `volunteers` fields across `PROJECTS`. To change the home-page strip numbers, edit those per-project fields — do not hardcode aggregate values. `totalProjects` is a manual count of non-deprecated products.
+
+`teacherImpact` is intentionally a teacher-domain-filtered count for some products (e.g. Whine uses 109, not its 568 raw user count). See `dev.md` for the filter criteria.
+
+### Status drives behaviour
+
+`ProjectStatus = "Building" | "Prototype" | "Maintenance" | "Deprecated"` is the only state machine in the app:
+- Index sorts by `STATUS_ORDER` (Building → Maintenance → Prototype → Deprecated), then by `since` desc.
+- Detail page hides the Join CTA when status is `Deprecated`.
+- Detail page renders `<DeprecatedAlternative>` when status is `Deprecated` **and** `alternative` is set.
+- Status badge colours and the OG image status pill are keyed off the same union.
+
+If you add a status value, update: `STATUS_ORDER` in `app/page.tsx`, `STATUS_CONFIG` in `components/project-card.tsx`, and `STATUS_COLOR`/`STATUS_BG` in `app/[slug]/opengraph-image.tsx`.
+
+### Brand tokens (dark mode only)
+
+`app/globals.css` is the single source of design tokens. The site is **dark-mode-only** — there is no light variant and no theme toggle. Use the CSS-variable-backed Tailwind utilities (`bg-card`, `text-primary`, `text-muted-foreground`, etc.), not raw hex values. `string-brand.md` documents the full token system and component patterns; read it before adding new visual styles.
+
+**Gotcha:** there are two `globals.css` files. `app/globals.css` is the active one (imported by `app/layout.tsx`) — String brand, dark mode. `styles/globals.css` is the shadcn-default OKLCH starter and is **unused**; don't edit it expecting changes to apply. Consider removing it if cleaning up.
+
+### shadcn/ui
+
+Configured via `components.json` (style: `new-york`, base: `neutral`, RSC, lucide icons). Components live under `components/ui/`. Most are installed but unused by current pages — only `components/project-card.tsx` and `components/deprecated-alternative.tsx` are wired in. Prefer extending these app-level components over pulling in more shadcn primitives unless genuinely needed.
+
+### OpenGraph images
+
+Generated at request/build time via `next/og` `ImageResponse`:
+- `app/opengraph-image.tsx` → index
+- `app/[slug]/opengraph-image.tsx` → per-project
+
+Next.js auto-discovers these file-conventional routes. **Do not** add `openGraph.images` to `app/layout.tsx` metadata — it will conflict. Inside the OG handlers, colours are inlined as hex (CSS variables don't apply in `ImageResponse`) and `fontFamily` is system `sans-serif` (custom fonts would require `fetch()`-ing the font file in the handler).
+
+### Path alias
+
+`@/*` → repo root (`tsconfig.json`). Imports use `@/lib/...`, `@/components/...`, `@/hooks/...`.
+
+### Async params
+
+App Router pages and OG handlers receive `params: Promise<{ slug: string }>` — always `await params` before destructuring. This matches Next.js 16 conventions.
+
+## Conventions
+
+- **External links** always include `target="_blank"` and `rel="noopener noreferrer"`.
+- **Card click pattern**: project cards use an invisible full-card `<Link>` with `absolute inset-0`; interactive children inside (e.g. "Try it") use `relative z-10` to sit above it. Don't nest `<a>` inside `<Link>`.
+- **Volunteer counts**: the `volunteers` numeric field on a project overrides `contributors.length` for display. Use it when the real headcount is known but contributor names aren't yet filled in.
+- **Headings** use Space Grotesk (`--font-space-grotesk`); body uses Montserrat (`--font-montserrat`). Both are loaded via `next/font/google` in `app/layout.tsx`.
+
+## Notable config
+
+- `next.config.mjs` sets `typescript.ignoreBuildErrors: true` and `images.unoptimized: true`. Type errors won't block production builds — run `npx tsc --noEmit` if you need to verify types. Images are unoptimised because the site is small and deployed statically.
+- `dev.md` is the running change log / decision record. When making non-trivial product or data decisions (status changes, aggregate methodology, new audience/problem types), append a dated entry there.
+
+## Branch
+
+Development happens on `claude/add-claude-documentation-ofJf0` (per session instructions). Push to that branch and open a draft PR.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
 # String Reports
 
-Public-facing product reports for the String volunteer-run edutech ecosystem. Tracks metrics, updates, and impact across all active and past products.
+Public-facing impact reports for the [String](https://string.sg) volunteer-run edutech ecosystem. Tracks metrics, updates, and impact across all active and past products.
 
-Built with Next.js + Tailwind CSS v4. Deployed on Vercel.
+**Live site → [reports.string.sg](https://reports.string.sg)**
 
-## Live Site
+---
 
-[reports.string.sg](https://reports.string.sg)
+## Table of Contents
+
+- [Products](#products)
+- [Getting Started](#getting-started)
+- [Architecture](#architecture)
+- [Dependencies](#dependencies)
+- [Opportunities to Contribute](#opportunities-to-contribute)
+- [Contributing](#contributing)
+
+---
 
 ## Products
 
@@ -15,17 +24,204 @@ Built with Next.js + Tailwind CSS v4. Deployed on Vercel.
 | String — Solutions Aggregator | Building | [/string-solutions](https://reports.string.sg/string-solutions) |
 | Events | Building | [/events](https://reports.string.sg/events) |
 | Diagrams | Building | [/diagrams](https://reports.string.sg/diagrams) |
+| MatCHER | Building | [/matcher](https://reports.string.sg/matcher) |
 | Bingo | Maintenance | [/bingo](https://reports.string.sg/bingo) |
 | Whine — Problem Bank | Deprecated | [/whine](https://reports.string.sg/whine) |
 | Remarks Co-Pilot | Deprecated | [/remarkscopilot](https://reports.string.sg/remarkscopilot) |
 
-## Development
+---
+
+## Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) v18 or later
+- npm (bundled with Node.js)
+
+### Installation
 
 ```bash
+git clone https://github.com/String-sg/reports.git
+cd reports
 npm install
+```
+
+### Local development
+
+```bash
 npm run dev
 ```
 
+Opens at [http://localhost:3000](http://localhost:3000) with hot-reload.
+
+### Build for production
+
+```bash
+npm run build   # static export via Next.js
+npm run start   # serve the built output locally
+```
+
+### Lint
+
+```bash
+npm run lint    # runs eslint on the whole project
+```
+
+> **Note:** `eslint` is referenced in the `lint` script but is not yet listed in `devDependencies`. Run `npm install -D eslint` (or add it to `package.json`) before using this command. The `build` step does not block on TypeScript errors (`typescript.ignoreBuildErrors: true` in `next.config.mjs`) — run `npx tsc --noEmit` to check types manually.
+
+---
+
+## Architecture
+
+### Tech stack
+
+| Layer | Choice |
+|-------|--------|
+| Framework | [Next.js 16](https://nextjs.org/) (App Router) |
+| UI | [React 19](https://react.dev/) + [shadcn/ui](https://ui.shadcn.com/) |
+| Styling | [Tailwind CSS v4](https://tailwindcss.com/) |
+| Analytics | [@vercel/analytics](https://vercel.com/analytics) |
+| Deployment | [Vercel](https://vercel.com/) |
+
+### Directory structure
+
+```
+reports/
+├── app/
+│   ├── layout.tsx              # Root layout — fonts, metadata, analytics
+│   ├── page.tsx                # Index page — lists all products
+│   ├── globals.css             # ✅ Active design tokens (dark-mode-only)
+│   ├── opengraph-image.tsx     # OG image for the index page
+│   └── [slug]/
+│       ├── page.tsx            # Dynamic product detail page
+│       └── opengraph-image.tsx # OG image per product
+├── components/
+│   ├── project-card.tsx        # Product card used on the index
+│   ├── deprecated-alternative.tsx  # Amber banner for deprecated products
+│   └── ui/                     # shadcn/ui primitives (mostly installed, partially used)
+├── lib/
+│   └── data.ts                 # ⭐ Single source of truth for all product data
+├── styles/
+│   └── globals.css             # ⚠️  Unused shadcn-default starter — do not edit
+├── public/                     # Static assets (favicons, icons)
+├── next.config.mjs
+├── components.json             # shadcn/ui config
+└── tsconfig.json
+```
+
+### Content model
+
+All product data lives in **`lib/data.ts`** as a single typed array `PROJECTS: Project[]`. There is exactly one dynamic route (`app/[slug]/page.tsx`) that renders any product by its slug. `generateStaticParams` enumerates `PROJECTS` at build time so every report is statically generated.
+
+**To add a new product report, add one entry to `PROJECTS` — no new page file is needed.**
+
+Key fields on `Project`:
+
+| Field | Purpose |
+|-------|---------|
+| `slug` | URL path — e.g. `"bingo"` → `/bingo` |
+| `status` | `"Building"` \| `"Prototype"` \| `"Maintenance"` \| `"Deprecated"` |
+| `teacherImpact` | Teacher-domain filtered user count. Feeds the "Teachers reached" aggregate on the home page. |
+| `volunteers` | Volunteer headcount (overrides `contributors.length` for display). |
+| `alternative` | If set and status is `Deprecated`, renders the amber alternative-product banner. |
+| `highlightStat` | The single prominent stat shown on the product card and OG image. |
+
+### Aggregate stats
+
+`AGGREGATE` (bottom of `lib/data.ts`) auto-computes:
+- **`totalUsers`** — sum of `teacherImpact` across all projects
+- **`totalVolunteers`** — sum of `volunteers` across all projects
+- **`totalProjects`** — manual count of non-deprecated products
+
+To change the home-page stat strip, edit the per-project fields — do not hardcode the aggregate values. Note that `totalUsers` and `totalVolunteers` are auto-computed from `PROJECTS`, but `totalProjects` is a manually maintained count of non-deprecated products and must be updated whenever a product changes status.
+
+### Status-driven behaviour
+
+| Status | Sort order | Join CTA | Deprecated banner |
+|--------|-----------|----------|-------------------|
+| Building | 1st | Shown | — |
+| Maintenance | 2nd | Shown | — |
+| Prototype | 3rd | Shown | — |
+| Deprecated | 4th | Hidden | Shown if `alternative` is set |
+
+If you add a new status value, update `STATUS_ORDER` in `app/page.tsx`, `STATUS_CONFIG` in `components/project-card.tsx`, and `STATUS_COLOR`/`STATUS_BG` in `app/[slug]/opengraph-image.tsx`.
+
+### OpenGraph images
+
+Dynamic OG images are generated at build time via `next/og` `ImageResponse`:
+
+| File | Route |
+|------|-------|
+| `app/opengraph-image.tsx` | `/` (index) |
+| `app/[slug]/opengraph-image.tsx` | `/<slug>` (per product) |
+
+Next.js auto-discovers these via file conventions. **Do not** add `openGraph.images` to `app/layout.tsx` metadata — it will conflict. Colours inside OG handlers are inlined as hex (CSS variables are not available in `ImageResponse`).
+
+### Brand & design tokens
+
+The site is **dark-mode only** — there is no light theme or theme toggle. Design tokens are defined in `app/globals.css` and consumed via Tailwind utilities (`bg-card`, `text-primary`, `text-muted-foreground`, etc.). See `string-brand.md` for the full token reference.
+
+Fonts are loaded via `next/font/google`:
+- **Headings** — Space Grotesk (`--font-space-grotesk`)
+- **Body / UI** — Montserrat (`--font-montserrat`)
+
+---
+
+## Dependencies
+
+### Runtime dependencies (key packages)
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `next` | 16.2.0 | Framework — App Router, static generation, OG images |
+| `react` / `react-dom` | 19.2.x | UI rendering |
+| `tailwindcss` | ^4.2.0 | Utility-first CSS |
+| `@vercel/analytics` | 1.6.1 | Page-view analytics |
+| `lucide-react` | ^0.564.0 | Icon set |
+| `class-variance-authority` | ^0.7.1 | Variant-based class composition (shadcn/ui) |
+| `clsx` + `tailwind-merge` | latest | Conditional class merging |
+| `@radix-ui/*` | various | Headless UI primitives (installed via shadcn/ui) |
+
+Most `@radix-ui/*` packages are installed via the shadcn/ui setup but are not actively used by current pages — only `project-card.tsx` and `deprecated-alternative.tsx` are wired into the app.
+
+### Dev dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `typescript` | 5.7.3 | Static typing |
+| `@types/react` / `@types/react-dom` | 19.x | React type definitions |
+| `@tailwindcss/postcss` | ^4.2.0 | Tailwind v4 PostCSS integration |
+| `postcss` | ^8.5 | CSS processing |
+| `tw-animate-css` | 1.3.3 | Animation utilities for shadcn/ui |
+
+---
+
+## Opportunities to Contribute
+
+String is volunteer-run and always welcoming help. Here are the most impactful open areas:
+
+### 🗃 Data & content
+- **Add real contributor names** — `contributors` arrays in `lib/data.ts` are all currently empty (`[]`). Fill in names, roles, and initials.
+- **Update aggregate metrics** — `totalProjects` in `AGGREGATE` is a manually maintained count; update it when products change status. Per-product `teacherImpact` and `volunteers` fields also need keeping current (the aggregate totals are auto-computed from them).
+- **Populate Diagrams and Bingo metrics** — both products currently show "WIP / metrics coming soon".
+
+### 🎨 UI & design
+- **Prototype status badge** — the `Prototype` status exists in the type system but has no products using it yet; verify the badge renders correctly when needed.
+- **Remove `styles/globals.css`** — this file is the unused shadcn-default OKLCH starter; deleting it removes confusion for future contributors.
+- **Responsive polish** — the aggregate stats strip and some detail-page sections could benefit from additional mobile testing.
+
+### 🔧 Engineering
+- **Add ESLint to devDependencies** — `eslint` is referenced in the `lint` script but not yet listed in `package.json`; run `npm install -D eslint` and commit the updated `package.json`.
+- **Add a product** — the data model fully supports any new String product; just add an entry to `PROJECTS` in `lib/data.ts`.
+- **OG image typography** — OG images currently use the system `sans-serif` fallback. Loading Space Grotesk via a `fetch()` call in the OG handler would match the site's visual identity.
+
+### 📋 Process
+- **Review `dev.md` pending items** — a list of open decisions and TODOs is maintained in `dev.md`.
+
+---
+
 ## Contributing
 
-String runs entirely on volunteer effort. To contribute, visit [join.string.sg](https://join.string.sg).
+String runs entirely on volunteer effort. To join the team, visit [join.string.sg](https://join.string.sg).
+
+For technical questions or to discuss a contribution, open an issue or pull request in this repository.


### PR DESCRIPTION
## Summary

Adds a CLAUDE.md to orient AI assistants (and new contributors) to the repo's non-obvious conventions.

Covers:
- Commands (`dev`, `build`, `start`, `lint`) and the absence of a test suite
- Data-driven content model — `lib/data.ts` `PROJECTS` is the single source of truth; the dynamic `app/[slug]/page.tsx` renders every report
- Auto-computed aggregates from `teacherImpact` / `volunteers`, including the teacher-domain filter rationale
- Status-driven UI (sort order, Join CTA hiding, Deprecated banner) and the three places to update if statuses change
- Brand tokens (dark-mode-only) and the **two `globals.css` files** gotcha — `styles/globals.css` is unused
- `next/og` `ImageResponse` conventions (hex inlining, system font, file-convention discovery — don't add to `layout.tsx` metadata)
- shadcn/ui setup and which UI components are actually wired in
- Path alias, async `params`, and `next.config.mjs` flags (`ignoreBuildErrors`, `images.unoptimized`)
- External-link / overlay-card / typography conventions

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm guidance matches current `lib/data.ts` and routing

---
_Generated by [Claude Code](https://claude.ai/code/session_01NALFbUMjprQFHXo7bcvg4m)_